### PR TITLE
Fix all ##Headings to ## Headings

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,14 +1,14 @@
-#Dragon Pants
+# Dragon Pants
 Copyright (c) 2006-2016 Megan Bednarz & Lars Doucet  
 [Dragon Pants](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/) by Megan Bednarz & Lars Doucet is licensed under a [Creative Commons Attribution-NonCommercial 4.0 International License](http://creativecommons.org/licenses/by-nc/4.0/).
 
 If you would like to obtain a different license for this work (such as a commercial license) feel free to contact the authors.
 
-#Surmount
+# Surmount
 Copyright (c) 2004-2016 Sean Choate & Lars Doucet  
 [Surmount](https://github.com/larsiusprime/boardgames/tree/master/surmount/) by Sean Choate & Lars Doucet is licensed under a [Creative Commons Attribution-NonCommercial 4.0 International License](http://creativecommons.org/licenses/by-nc/4.0/)
 
-#Ninja Havoc Machines
+# Ninja Havoc Machines
 
 This one's complicated as it's based on an existing work, [Robo Battle Pigs](http://cox-tv.com/games/mygames/robobattlepigs.html). I suppose I should give Randy Cox a call and sort out permission for an open licensing situation once and for all.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Board Games
+# Board Games
 Some board games I designed with my friends over the years, making them open source now.
 
 ## [Dragon Pants](/dragon_pants)

--- a/dragon_pants/CARDS.md
+++ b/dragon_pants/CARDS.md
@@ -1,4 +1,4 @@
-#Power Cards
+# Power Cards
 
 Cards can only be used on your turn, unless they're reaction cards.
 

--- a/dragon_pants/MATERIALS.md
+++ b/dragon_pants/MATERIALS.md
@@ -1,4 +1,4 @@
-#Materials
+# Materials
 
 You can play this game with just stuff you have lying around your house, but an "official" Dragon Pants set would
 look like this:

--- a/dragon_pants/PRINTING.md
+++ b/dragon_pants/PRINTING.md
@@ -1,24 +1,24 @@
-#Printing
+# Printing
 
-#1. Do It Yourself
+# 1. Do It Yourself
 
 To do a quick-and-dirty print & play version of Dragon Pants, just head over to the [print section](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print)
 and print out board.pdf and cards.pdf on a regular desktop printer. Black & White laser printer works best, but any will do.
 
 Then just cut the cards and board sections out along the lines, assemble the board to match the instructions, and you're ready to go! For keeping track of time, just use a piece of paper and a pencil. For dragon pawns, use pawns from another board game, bottle caps, coins, anything really.
 
-#2. Do It Fancy
+# 2. Do It Fancy
 
 If you want to print high-quality cards yourself, you can use a service like [MakePlayingCards.com](http://www.makeplayingcards.com/) and use the hiqh-quality images included in this repository. You're more than free to print high quality reproductions for your own use, or for your friends, so long as you're doing it at cost. This is a non-commercially licensed product, but if you want to do a commercial production run you can contact the authors for a special license.
 
-##[Cards](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/cards)
+## [Cards](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/cards)
 
 These cards are designed for 300 DPI @ poker card size (2.48" x 3.46" / 63mm x 88mm).
 
-##[Tiles](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/tiles)
+## [Tiles](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/tiles)
 
 The hex tiles are designed for 300 DPI @ 3.25" x 3.75" / 83mm x 95mm. You can print some hex tiles using the images from this repository if you want, but honestly if you already have a board game lying around your house that uses hexagon tiles, you'll probably have a better experience just borrowing some of those. *Settlers of Catan* works great, for instance -- just use water for water tiles, mountain for mountain tiles, and the red brick zones for power tiles. For land tiles, just use the blank white backs of the hexes, and for dragon dens just use blank white hexes, or the sea ports or something.
 
-##[Miscellaneous](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/misc)
+## [Miscellaneous](https://github.com/larsiusprime/boardgames/tree/master/dragon_pants/print/misc)
 
 You can print off the time card from the link above.

--- a/dragon_pants/README.md
+++ b/dragon_pants/README.md
@@ -1,6 +1,6 @@
 ![Dragon Pants Logo](/dragon_pants/images/logo_color.png)
 
-#Dragon Pants
+# Dragon Pants
 
 *Alternatively, "Dragon Trousers" in the U.K. and Europe*
 
@@ -8,33 +8,33 @@ Designed by Megan Bednarz and Lars Doucet
 
 [![](https://i.creativecommons.org/l/by-nc/4.0/88x31.png)](https://github.com/larsiusprime/boardgames/tree/master/LICENSE.md)
 
-##Overview
+## Overview
 
 2-6 players  
 Playtime: ~30 minutes  
 Suggested age: 10+ maybe?
 
-##Summary
+## Summary
 
 Players take turns moving their dragons across the board, taking advantage of terrain tiles, and drawing and using power cards, all in the hopes of controlling a legendary artifact of ultimate power: a handsomely tailored and comfortably stylish pair of denim work jeans known as *The Pants*. The Pants can only be worn by one dragon at a time, but control is fleeting as it's only a matter of time until another dragon pries The Pants loose from their owner's claws. Time ticks down one card at a time whenever a dragon wearing The Pants ends their turn. The game concludes when the timer runs out, and whichever dragon happens to be wearing The Pants at that moment wins.
 
-##[Materials](MATERIALS.md)
+## [Materials](MATERIALS.md)
 
-##[Setup](SETUP.md)
+## [Setup](SETUP.md)
 
-##[Rules](RULES.md)
+## [Rules](RULES.md)
 
-##[Cards](CARDS.md)
+## [Cards](CARDS.md)
 
-##[Printing](PRINTING.md)
+## [Printing](PRINTING.md)
 
-##Credits
+## Credits
 
-###Design
+### Design
 - Megan Bednarz
 - Lars Doucet
 
-###Stock Imagery sourced from:
+### Stock Imagery sourced from:
 
 - [Game-icons.net](http://game-icons.net/)  
 - [Jamiecat](https://www.flickr.com/photos/jamiecat/4878986494/)

--- a/dragon_pants/RULES.md
+++ b/dragon_pants/RULES.md
@@ -1,10 +1,10 @@
-#Rules
+# Rules
 
-##1. Getting Started
+## 1. Getting Started
 
  The player who received The Pants during setup goes first. Each player takes turns in order, with player proceeding to the left. All players begin with their power card face-up, and any future cards the player receives will always stay face up -- each player's hand is public information.
  
-##2. Taking a turn
+## 2. Taking a turn
 
  A player may take up to two (2) *actions* on a turn. An *action* is defined as either moving their dragon one tile to an adjacent hexagon, drawing a card from the Deck of Power, or playing a card from their hand.
  
@@ -17,33 +17,33 @@
  - Draw one (1) card and play one (1) card
  - Play two (2) cards
  
-##3. Moving
+## 3. Moving
 
  A player may move onto any space on the board, except for a mountain tile with another dragon on it. A player may move onto a tile occupied by another dragon (see "Biting"), a water tile, a land tile, or a power tile. 
  
  A player starts the game on their own Den tile, and may be forced back here at certain times by other player's actions. However, a player may never voluntarily move into a Den tile, and if they start their turn standing on a Den tile, they *must* immediately move out of it as their first action. A player standing on a den tile may not use power cards, and a player wearing The Pants who ends their turn on a Den tile for any reason may not draw a Destiny card.
  
-##4. Drawing cards
+## 4. Drawing cards
  
  A player may *only* use an action to draw from the Deck of Power if they began that action standing on a Power Tile (the gold tiles marked with a star). For example, if a player is merely standing adjacent to a Power Tile, they may not draw two Power cards this turn, as they must spend one action to move to the Power Tile, then another action to draw a card. If, however, a player started their turn standing on a Power Tile, they may use both actions to draw two cards. 
  
-###A. Discarding cards
+### A. Discarding cards
 
  Various events in the game will cause a player to discard cards; they should be placed face-up into a separate discard pile next to the Deck of Power.
  
-###B. Card choice
+### B. Card choice
  
  If there are any cards in the discard pile next to the Deck of Power, a player may use their draw action to draw a single card from *either* the top of the discard pile (face-up) *or* the top of the Deck of Power (face-down). (The player can either get the known item on top of the discards, or a fresh but random item from the shuffled deck -- drawing from the discards is a common way to acquire The Pants!)
  
-###C. Hand Limit
+### C. Hand Limit
  
  Players have a hand limit of 3 cards. If at any moment a player holds 4 cards (whether by drawing a new card or stealing it from another player), that player must immediately discard one of their cards (their choice).
  
-###D. Re-shuffling
+### D. Re-shuffling
  
  When a player spends an action to draw a card from the Deck of Power, but there are no cards available, that player takes all the cards in the discard pile, shuffles them, and places them on the board face-down as a replenished Deck of Power. The player then draws their card from the top of the Deck of Power.
  
-##5. Biting other dragons
+## 5. Biting other dragons
 
  A player may *bite* another player by moving their dragon into the same tile as the other player's dragon. The biting dragon  now occupies that tile, and the bitten dragon moves back to their den tile. Additionally, the biting dragon selects one power card from the bitten dragon's hand and adds it to their own hand.
  
@@ -51,13 +51,13 @@
  
  For the purposes of reaction cards, a bite counts as an *attack* and as a *theft*.
  
-##6. Playing Power cards
+## 6. Playing Power cards
  
   A player may play a Power card as one of their actions by declaring which card they are using and flipping it face down, marking it as "spent." The card will remain "spent" until the end of their *next* turn, at which time the player may flip it face up again.
  
   However, most cards can only be used in certain situations, so a card can only be played if the card-specific conditions are met. See the next section, "Power Cards" for details.
 
-###A. Line of sight
+### A. Line of sight
   
   Certain ranged Power cards such as Fireball and Shock require you to have "line of sight" with another player. There are two forms of "line of sight" -- flat-line (ex: Fireball), and diagonal-line (ex: Shock). 
   
@@ -75,7 +75,7 @@
   
   Water tiles confer immunity to line-of-sight powers, but do not block line-of-sight powers the way mountains do. (The dragon on that tile is hiding underneath the water and any attack would fly straight over them). Dragons standing on a water tile are still able to use line-of-sight powers themselves, however (they duck their heads above water to attack).
   
-###B. Reaction powers
+### B. Reaction powers
   
   Some cards (Poison, Rubber Ducky) can only be used in reaction to other powers. When a card is used against you that triggers one of your reaction powers, at that moment you *may elect* to immediately use your reaction power in response, but you do not have to. Two conditions must be met: 1) the reaction must be legal (see the card's rules), and 2) the reaction card must not be spent (it must be face-up). A reaction card used in this way remains "spent" until the end of your *next* turn. 
   
@@ -83,7 +83,7 @@
   
   Example 2: Emily is player 4 in a four player game and it is Lars's turn (he's player 3). He hits her with a freeze spell, and she uses her Amulet in response, canceling the freeze, marking the Amulet as "spent." The Amulet will not be available until Emily finishes her *next* turn which is... really soon! Lars ends his turn and now it's Emily's turn. She takes some actions, ends her turn, and flips her Amulet back over, fully charged and ready to go.
 
-##7. Wearing The Pants
+## 7. Wearing The Pants
 
  Whenever a player currently holding The Pants ends their turn, they draw a card from the Deck of Destiny and reveal it face up in a discard pile next to the Deck of Destiny. They then move the time status token a corresponding number of spaces. Example: Sean begins his turn with the time status token on "10." He ends his turn wearing the pants, and draws a Destiny card. It's "-1", so he moves the time status token to "9". Next turn, Lars steals the pants and draws a "-2", he moves the time status token to "7". On the next three turns, nobody steals the pants, so no Destiny card is drawn. Now it's Sean's turn again, he steals the pants back from Lars, and draws a "+1", moving the time status token to "8".
  

--- a/dragon_pants/SETUP.md
+++ b/dragon_pants/SETUP.md
@@ -1,4 +1,4 @@
-#Setup
+# Setup
 
 1. Arrange the hexagonal tiles like this:
 

--- a/ninja_havoc_machines/README.md
+++ b/ninja_havoc_machines/README.md
@@ -8,25 +8,25 @@ by Sean Choate and Lars Doucet
 
 a derivative work of [Robo Battle Pigs](http://cox-tv.com/games/mygames/robobattlepigs.html) by Randy Cox
 
-##Overview
+## Overview
 
 2 to as many players as you can cram on a standard-sized chess board  
 Playtime: ~10 minutes per session  
 Suggested age: 10+ maybe?  
 
-##Summary
+## Summary
 A game about customizable programmable robots battling to the death. All you need to play is a standard 8x8 checkers/chess board, paper & pens/pencils, and random
 junk or toys you have lying around your house like bottlecaps or coins or whatever. By far the most popular board game I've ever worked on.
 
-##Credits
+## Credits
 
-###Design
+### Design
 - Sean Choate
 - Lars Doucet
 
-###Original game "Robo Battle Pigs"
+### Original game "Robo Battle Pigs"
 - Randy Cox
 
-##Notes
+## Notes
 
 Just got the super old PDF dump of the old rulebook, needs some updating. For one, don't ever bother with the teleporter, it's kind of stupid.

--- a/surmount/CONSTRUCTION.md
+++ b/surmount/CONSTRUCTION.md
@@ -1,1 +1,1 @@
-#Construction
+# Construction

--- a/surmount/MATERIALS.md
+++ b/surmount/MATERIALS.md
@@ -1,4 +1,4 @@
-#Materials
+# Materials
 
 You can build this game set yourself out of certain common items, but an "official" Surmount set would look like this:
 

--- a/surmount/README.md
+++ b/surmount/README.md
@@ -4,28 +4,28 @@
 
 by Sean Choate and Lars Doucet
 
-##Overview
+## Overview
 
 2 or 4 players  
 Playtime: ~30 minutes  
 Suggested age: 10+ maybe?
 
-##Summary
+## Summary
 
 Players take turns moving blocks across a four-tiered 3D pyramid in a bid to capture their opponent's home spaces. Blocks can be stacked on either friendly or opposing pieces, and whoever controls the piece on top of a stack controls the whole stack. Should you spend time conquering the high ground? Or sneak around the low-lying edges?
 
 This is kind of like one of those fancy-pants abstract board games suburban helicopter parents buy from Mensa catalogs so their children will become geniuses. Except this one's actually fun! Probably!
 
-##[Materials](MATERIALS.md)
+## [Materials](MATERIALS.md)
 
-##[Setup](SETUP.md)
+## [Setup](SETUP.md)
 
-##[Rules](RULES.md)
+## [Rules](RULES.md)
 
-##[Construction](CONSTRUCTION.md)
+## [Construction](CONSTRUCTION.md)
 
-##Credits
+## Credits
 
-###Design
+### Design
 - Sean Choate
 - Lars Doucet

--- a/surmount/RULES.md
+++ b/surmount/RULES.md
@@ -1,18 +1,18 @@
-#Rules
+# Rules
 
-##1. Moving
+## 1. Moving
 
 On your turn, you may move one block (or one stack) by one space. You may move only in orthogonal directions, diagonal movement is not allowed. You may always move onto an unoccupied space at the same level as your block. You may also move vertically upwards and downwards. If you move a block or stack off of its current level such that there is nothing below it, it will "fall" until the block or stack reaches solid ground. A block or stack may move downwards by several levels in a single move in this way.
 
-##2. Vertical movement
+## 2. Vertical movement
 
 Only single blocks may move upwards vertically. Single blocks may always move up by one level as part of a normal orthogonal move, so long as they are entering an unoccupied space. Single blocks may *not* move upwards by more than one vertical level. Single blocks may also "climb" blocks of the same color the same way they can climb the board itself, but cannot "climb" blocks of another color. Moving upwards in this way requires both blocks to start on the same vertical level. Blocks may, however, always "slide" onto the top surface of other blocks occupying the level immediately below them, regardless of color. 
 
-##3. Stacks
+## 3. Stacks
 
 When a block climbs onto a friendly block, or slides onto an opponent's block, it forms a vertical stack of blocks. The player who controls the block on top of the stack controls the entire stack. Any player whose blocks are contained in the stack, but who does not control the top block, may not move any of their pieces contained within it unless they regain control of the stack. The player who controls the stack may move the entire stack as one piece, but may still only move it by one space per turn. Unlike single blocks, stacks cannot climb vertically under any circumstances, though the controlling player may "split" the stack at any level by sliding the top piece and any number of pieces below it off of the stack onto an adjacent space. In some cases this will reveal an opponent's piece on the top of the remaining stack or single block, which will revert control of that remaining stack or block to that opponent.
 
-##4. Winning the Game
+## 4. Winning the Game
 
 When you control all four of your opponent's inner home spaces, you win the game. "Control" means that you 1) have one of your blocks occupying that space, and 2) you control the stack that block belongs to, if any. If you have a block occupying a goal space, but it belongs to a stack controlled by another player, that doesn't count. If you control a stack occupying a goal space, but the block on the bottom of the stack is not your, that doesn't count.
 

--- a/surmount/SETUP.md
+++ b/surmount/SETUP.md
@@ -1,6 +1,6 @@
-#Setup
+# Setup
 
-##1. Setup the board
+## 1. Setup the board
 
 For a two-player game, the board should look like this:
 
@@ -16,7 +16,7 @@ For a two-player game, the board should look like this:
   
   ![](/surmount/images/board_2player_blank_notop2.png)
   
-##2. Place blocks
+## 2. Place blocks
 
 Place the eight red blocks on the eight red home spaces, and the eight blue blocks on eight the blue home spaces.
 


### PR DESCRIPTION
To see this in action: https://github.com/edbrannin/boardgames/tree/fix-markdown-headings or click the Rich Diff buttons below: 
<img width="215" alt="image" src="https://user-images.githubusercontent.com/121909/38034467-5652c938-3270-11e8-83fc-74bca53d03c2.png">


The conversion script:
```python
"Fix all the headings in this repo"

import re
import fileinput
import os
import sys

HEADING_REGEX = re.compile(r'^(#+)([^ #].*)', re.DOTALL)

def all_markdowns(path='.'):
    "Return all .md files in the given tree"
    for root, _, files in os.walk(path):
        for f in files:
            if f.endswith('.md'):
                yield os.path.join(root, f)

def process(line):
    """
    If line is a Markdown header without a space between '#' and the rest, fix that.
    Otherwise, return the original line.
    """
    match = HEADING_REGEX.match(line)
    if not match:
        return line
    return '{} {}'.format(match.group(1), match.group(2))

def main():
    "Fix all files in the current directory"
    files = list(all_markdowns())
    for line in fileinput.input(files, inplace=True):
        sys.stdout.write(process(line))

if __name__ == '__main__':
    main()

def test_process():
    "Unit tests -- run with py.test"
    assert process('Hello There') == 'Hello There'
    assert process('# Hello There') == '# Hello There'
    assert process('## Hello There') == '## Hello There'
    assert process('##Hello There') == '## Hello There'
    assert process('Hello ##There') == 'Hello ##There'
```